### PR TITLE
Fix bug clipboard not copy when input

### DIFF
--- a/src/components/mobile/NumberPadSheet.vue
+++ b/src/components/mobile/NumberPadSheet.vue
@@ -237,18 +237,17 @@ function inputTripleNum(num: number): void {
 async function pasteFromClipboard(): void {
     try {
         const clipboardText = await navigator.clipboard.readText();
-        // Remove all non-digit characters, keeping only numbers
         const sanitizedText = clipboardText.replace(/\D/g, '');
         
         const num = parseInt(sanitizedText);
 
         if (!isNaN(num)) {
-            this.inputNum(num);
+            inputNum(num);
         } else {
-            this.$toast('Clipboard does not contain a valid numeric value!');
+            showToast('Clipboard does not contain a valid numeric value!');
         }
     } catch (err) {
-        this.$toast(err.message);
+        showToast(err.message);
     }
 }
 


### PR DESCRIPTION
Update `pasteFromClipboard` method in `src/components/mobile/NumberPadSheet.vue` to handle non-numeric clipboard content gracefully.

* Replace all non-digit characters in clipboard text with an empty string.
* Input the sanitized number if it is valid.
* Show a toast message if the clipboard does not contain a valid numeric value.
* Show a toast message if an error occurs while reading the clipboard.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/f97/ezbookkeeping/pull/3?shareId=3cf97645-0062-4f89-8670-44aaeb25708a).