### PR TITLE
Fix amount input for Vietnamese currency

### DIFF
--- a/src/components/desktop/AmountInput.vue
+++ b/src/components/desktop/AmountInput.vue
@@ -228,7 +228,10 @@ function onKeyUpDown(e: KeyboardEvent): void {
     }
 
     try {
-        const val = parseAmount(str);
+        let val = parseAmount(str);
+        if (props.currency === 'VND' && val < 100) {
+            val *= 1000;
+        }
         const finalValue = getValidFormattedValue(val, str, decimalIndex >= 0);
 
         if (finalValue !== str) {
@@ -255,7 +258,10 @@ function onPaste(e: ClipboardEvent): void {
         return;
     }
 
-    const value = parseAmount(text);
+    let value = parseAmount(text);
+    if (props.currency === 'VND' && value < 100) {
+        value *= 1000;
+    }
     const textualValue = getFormattedValue(value);
     const decimalSeparator = getCurrentDecimalSeparator();
     const hasDecimalSeparator = text.indexOf(decimalSeparator) >= 0;

--- a/src/components/mobile/NumberPadSheet.vue
+++ b/src/components/mobile/NumberPadSheet.vue
@@ -362,6 +362,10 @@ function confirm(): boolean {
     } else {
         let value: number = parseAmount(currentValue.value);
 
+        if (props.currency === 'VND' && value < 100) {
+            value *= 1000;
+        }
+
         if (props.flipNegative) {
             value = -value;
         }


### PR DESCRIPTION
Add logic to multiply the input amount by 1000 if it is less than 100 for Vietnamese currency.

* **Desktop Amount Input**:
  - Update `onKeyUpDown` function in `src/components/desktop/AmountInput.vue` to multiply the input amount by 1000 if it is less than 100.
  - Update `onPaste` function in `src/components/desktop/AmountInput.vue` to multiply the input amount by 1000 if it is less than 100.

* **Mobile Number Pad**:
  - Update `confirm` function in `src/components/mobile/NumberPadSheet.vue` to multiply the input amount by 1000 if it is less than 100.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/f97/ezbookkeeping/pull/8?shareId=1927238f-e569-469a-9c04-7e41045be6b2).